### PR TITLE
chore: add .gitignore for OS, IDE, Go, and Alfred junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100/
+.Trashes/
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# JetBrains
+.idea/
+*.iml
+
+# VS Code
+.vscode/
+
+# Go
+*.test
+coverage.out
+
+# Alfred
+*.alfredworkflow


### PR DESCRIPTION
## Summary

Adds a repo-root `.gitignore` covering the patterns that normally show up as untracked files for contributors on macOS / Linux / Windows, plus the usual Go and Alfred build artifacts.

## What's covered

- **macOS**: `.DS_Store`, `._*`, `.Spotlight-V100/`, `.Trashes/`, etc.
- **Windows**: `Thumbs.db`, `ehthumbs.db`, `Desktop.ini`, `$RECYCLE.BIN/`
- **JetBrains / VS Code**: `.idea/`, `*.iml`, `.vscode/`
- **Go**: `*.test`, `coverage.out`
- **Alfred**: `*.alfredworkflow` (release artifact, not source)

## Notes

- No tracked files needed removal — this is purely additive.
- Verified with `git check-ignore -v` for each pattern.